### PR TITLE
[iss-9] Configure post credits in theme options

### DIFF
--- a/catch-base-pro/content-single.php
+++ b/catch-base-pro/content-single.php
@@ -8,14 +8,29 @@
  */
 ?>
 
+<?php
+// Get theme options
+$options = catchbase_get_theme_options();
+?>
+
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	
 	<header class="post-credits">
 		<?php if ( !empty( get_field('author') ) ) : ?>
-			<h2 class="entry-author post-credits-author"><?php printf('Text by %s', get_field('author')); ?></h2>
+			<h2 class="entry-author post-credits-author">
+				<?php printf(
+					'%s %s',
+					$options['post_author_credit_text'],
+					get_field('author')); ?>
+			</h2>
 		<?php endif; ?>
 		<?php if( !empty( get_field('illustrator') ) ) : ?>
-			<h2 class="entry-illustrator post-credits-illustrator"><?php printf('Image by %s', get_field('illustrator')); ?></h2>
+			<h2 class="entry-illustrator post-credits-illustrator">
+				<?php printf(
+					'%s %s',
+					$options['post_illustrator_credit_text'],
+					get_field('illustrator')); ?>
+			</h2>
 		<?php endif; ?>
 	</header>
 

--- a/catch-base-pro/inc/catchbase-default-options.php
+++ b/catch-base-pro/inc/catchbase-default-options.php
@@ -77,6 +77,12 @@ function catchbase_get_default_theme_options() {
 		//Pagination Options
 		'pagination_type'									=> 'default',
 
+		// Post Options
+		'post_author_credit_text'
+					=> 'Writing by',
+		'post_illustrator_credit_text'
+					=> 'Image by',
+
 		//Promotion Headline Options
 		'promotion_headline_option'							=> 'homepage',
 		'promotion_headline'								=> __( 'Catch Base Pro is a Premium Responsive WordPress Theme', 'catch-base' ),

--- a/catch-base-pro/inc/customizer-includes/catchbase-customizer-theme-options.php
+++ b/catch-base-pro/inc/customizer-includes/catchbase-customizer-theme-options.php
@@ -541,6 +541,42 @@ if ( ! defined( 'CATCHBASE_THEME_VERSION' ) ) {
 		'type'	   => 'select',
 	) );
 	// Pagination Options End
+	
+	// Post Options
+	$wp_customize->add_section( 'skindeep_post_options', array(
+		'panel'  	=> 'catchbase_theme_options',
+		'priority' 	=> 212,
+		'title'    	=> __( 'Post Options', 'catch-base' ),
+	) );
+
+	$wp_customize->add_setting( 'catchbase_theme_options[post_author_credit_text]', array(
+		'capability'		=> 'edit_theme_options',
+		'default'			=> $defaults['post_author_credit_text'],
+		'sanitize_callback'	=> 'sanitize_text_field',
+	) );
+
+	$wp_customize->add_control( 'post_author_credit_text', array(
+		'label'    => __( 'Author Credit', 'catch-base' ),
+		'description'	=> __( 'Text prepended to author name in credits for a post.'),
+		'section'  => 'skindeep_post_options',
+		'settings' => 'catchbase_theme_options[post_author_credit_text]',
+		'type'	   => 'text',
+	) );
+
+	$wp_customize->add_setting( 'catchbase_theme_options[post_illustrator_credit_text]', array(
+		'capability'		=> 'edit_theme_options',
+		'default'			=> $defaults['post_illustrator_credit_text'],
+		'sanitize_callback'	=> 'sanitize_text_field',
+	) );
+
+	$wp_customize->add_control( 'post_illustrator_credit_text', array(
+		'label'    => __( 'Illustrator Credit', 'catch-base' ),
+		'description'	=> __( 'Text prepended to illustrator name in credits for a post.'),
+		'section'  => 'skindeep_post_options',
+		'settings' => 'catchbase_theme_options[post_illustrator_credit_text]',
+		'type'	   => 'text',
+	) );
+	// Excerpt Options End
 
 	//Promotion Headline Options
     $wp_customize->add_section( 'catchbase_promotion_headline_options', array(


### PR DESCRIPTION
Added 'Post Options' to 'Theme Options' in customizer
Permitted configuration of author and illustrator credits (as prepended
text)