### PR TITLE
Improve styling for 'sidebar header right' widgets

### DIFF
--- a/catch-base-pro/css/responsive.css
+++ b/catch-base-pro/css/responsive.css
@@ -750,6 +750,10 @@ Responsive Style
 		margin: 0 0 1em;
 	}
 
+	.sidebar-header-right .widget {
+	    margin-bottom: 0;
+	}
+
 	#featured-content .entry-container {
 		margin-top: 10px;
 	}

--- a/catch-base-pro/style.css
+++ b/catch-base-pro/style.css
@@ -591,7 +591,16 @@ ul#menu-main-menu {
     line-height: normal;
     margin-left: auto;
     padding: 0;
-    padding-right: 2vw;
+    /*padding-right: 2vw;*/
+    display: flex;
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+}
+
+#masthead .sidebar-header-right section {
+    padding: 0px 2vw;
 }
 
 #masthead .wrapper {
@@ -903,11 +912,12 @@ textarea {
     height: 100%;
     z-index: 198;
     background-color: rgba(0,0,0,0);
+    white-space:nowrap;
+    overflow:hidden;
 }
 
 .nav-primary ul {
     line-height: 80px;
-    /* width: 100%; */
 }
 
 #masthead.stuck {
@@ -2425,7 +2435,7 @@ caption {
 
 /* Social Icons */
 .widget_catchbase_social_icons {
-    margin-bottom: 10px;
+    margin-bottom: 0px;
 }
 
 .widget_catchbase_social_icons .widget-wrap {

--- a/catch-base-pro/style.css
+++ b/catch-base-pro/style.css
@@ -591,7 +591,6 @@ ul#menu-main-menu {
     line-height: normal;
     margin-left: auto;
     padding: 0;
-    /*padding-right: 2vw;*/
     display: flex;
     flex-direction: row-reverse;
     flex-wrap: wrap;

--- a/catch-base-pro/style.css
+++ b/catch-base-pro/style.css
@@ -722,7 +722,7 @@ body.archive.category .page-title.hide-cat-title {
     margin-top: 20px;
 }
 
-.sidebar-header-right .widget:last-child {
+.sidebar-header-right .widget {
     margin-bottom: 0;
 }
 
@@ -2434,10 +2434,6 @@ caption {
 }
 
 /* Social Icons */
-.widget_catchbase_social_icons {
-    margin-bottom: 0px;
-}
-
 .widget_catchbase_social_icons .widget-wrap {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
Styling of widgets placed into the right of the header improved to sit spaced apart and responsive (wrapping when there is not enough space).

This is in support of #26.